### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete URL substring sanitization

### DIFF
--- a/skyalert-firehose.py
+++ b/skyalert-firehose.py
@@ -345,7 +345,8 @@ def worker_main(cursor_value: multiprocessing.Value, pool_queue: multiprocessing
                             if post.thread.post.embed.py_type.startswith("app.bsky.embed.video"):
                                 message1 += f" [has video]"
                             if post.thread.post.embed.external is not None:
-                                if "tenor.com" in post.thread.post.embed.external.uri:
+                                parsed_uri = urlparse(post.thread.post.embed.external.uri)
+                                if parsed_uri.hostname == "tenor.com":
                                     message1 += f" [has GIF]"
                                 else:
                                     message1 += f" [link preview]"

--- a/skyalert-firehose.py
+++ b/skyalert-firehose.py
@@ -13,6 +13,7 @@ import os
 import datetime
 import re
 import tenacity
+from urllib.parse import urlparse
 
 # code from original skyalert file, now skyalert-cmds.py
 
@@ -318,7 +319,6 @@ def worker_main(cursor_value: multiprocessing.Value, pool_queue: multiprocessing
                             if post.embed.py_type == "app.bsky.embed.images": message1 += f" [has images]"
                             if post.embed.py_type == "app.bsky.embed.video": message1 += f" [has video]"
                             if post.embed.py_type == "app.bsky.embed.external":
-                                from urllib.parse import urlparse
                                 parsed_uri = urlparse(post.embed.external.uri)
                                 if parsed_uri.hostname == "tenor.com": message1 += f" [has GIF]"
                                 else: message1 += f" [link preview]"

--- a/skyalert-firehose.py
+++ b/skyalert-firehose.py
@@ -318,7 +318,9 @@ def worker_main(cursor_value: multiprocessing.Value, pool_queue: multiprocessing
                             if post.embed.py_type == "app.bsky.embed.images": message1 += f" [has images]"
                             if post.embed.py_type == "app.bsky.embed.video": message1 += f" [has video]"
                             if post.embed.py_type == "app.bsky.embed.external":
-                                if "tenor.com" in post.embed.external.uri: message1 += f" [has GIF]"
+                                from urllib.parse import urlparse
+                                parsed_uri = urlparse(post.embed.external.uri)
+                                if parsed_uri.hostname == "tenor.com": message1 += f" [has GIF]"
                                 else: message1 += f" [link preview]"
                             if post.embed.py_type == "app.bsky.embed.record": message1 += f" [quote repost]"
                             

--- a/skyalert-jetstream.py
+++ b/skyalert-jetstream.py
@@ -11,6 +11,7 @@ import time
 import re
 import aiohttp
 import aiofiles
+from urllib.parse import urlparse
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
 CONFIG_FILE = os.path.join(DATA_DIR, 'config.yaml')
@@ -209,7 +210,8 @@ async def main(uri):
                                 if embed.get("$type") == "app.bsky.embed.video":
                                     message1 += " [has video]"
                                 if embed.get("$type") == "app.bsky.embed.external":
-                                    if "tenor.com" in embed.get("external").get("uri"):
+                                    parsed_uri = urlparse(embed.get("external").get("uri"))
+                                    if parsed_uri.hostname == "tenor.com":
                                         message1 += " [has GIF]"
                                     else:
                                         message1 += " [link preview]"


### PR DESCRIPTION
Potential fix for [https://github.com/littlebitstudios/SkyAlert/security/code-scanning/1](https://github.com/littlebitstudios/SkyAlert/security/code-scanning/1)

To fix the issue, the code should use the `urlparse` function from Python's `urllib.parse` module to parse the URL and validate its hostname. This ensures that the check is performed on the actual domain of the URL rather than relying on a substring match. Specifically, the hostname of the parsed URL should be compared to `tenor.com`.

Changes are required in the block where `"tenor.com" in post.embed.external.uri` is used. The `urlparse` function needs to be imported if not already present, and the logic should be updated to parse the URL and check its hostname.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
